### PR TITLE
Put newsletter under social

### DIFF
--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -32,6 +32,7 @@ stylesheets:
                         <li><a href="https://twitter.com/Robotics1418">Twitter</a></li>
                         <li><a href="https://github.com/frc1418">GitHub</a></li>
                         <li><a href="https://www.youtube.com/user/Robotics1418">YouTube</a></li>
+                        <li><a href="https://us12.campaign-archive.com/home/?u=116c018468396fe09157a44fe&id=1b1730bbc1">1418 Newsletter</a></li>
                     </ul>
                 </td>
                 <td>
@@ -40,12 +41,6 @@ stylesheets:
                         <br>7124 Leesburg Pike
                         <br>Falls Church, VA 22043</p>
                 </td>
-            </tr>
-            <tr>
-                <h5>Newsletter</h5>
-                <ul>
-                    <li><a href="https://us12.campaign-archive.com/home/?u=116c018468396fe09157a44fe&id=1b1730bbc1">1418 Newsletter</a></li>
-                </ul>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Fix #234

I thought that there should still be a link to the newsletter if people wanted to access it, so I just put it under the social heading. If you think it should be deleted entirely, I can amend.