### PR TITLE
Clarify licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ This website uses the Jekyll templating system and is hosted as a GitHub page ou
 * [Carter Fendley](https://github.com/CarterFendley) - Code
 
 ## License
-This software is protected under the MIT license. Basically, do whatever you want as long as you give credit where credit is due and don't hold us liable for anything that happens. More information can be found in [`LICENSE`](LICENSE).
+This software is protected under the [MIT license](LICENSE). You may reuse this code as long as you provide credit where it's due and don't hold us liable for anything that happens. However, we would prefer that other teams take the time to develop their own websites rather than stealing ours entirely or in substantial part.


### PR DESCRIPTION
Resolve #270 

As mentioned in the relevant issue, some teams, most notably [this team](https://evolution2626.org/), have copied almost all of our code and republished it as their own website. They change the content and logo (and font on their English website, not [French](https://fr.evolution2626.org/)). Other than that, it's identical.

The MIT license we use doesn't prohibit this, and in the spirit of open source I don't think we expressly should. However, it bothers me a little bit that teams are stealing our entire website rather than putting work into making their own unique one.

I've added a warning in the README section on Licensing, which advises against this sort of behavior. I am open to suggestions on how we can effectively fix this.