### PR TITLE
Fix AUVSI images

### DIFF
--- a/_pages/outreach.html
+++ b/_pages/outreach.html
@@ -132,12 +132,12 @@ description: A large part of what we do is helping the community around us and h
 			<h5>AUVSI House of Representatives Exhibit</h5>
 			    <p>FRC 1418 was asked to attend the 2016 Science and Technology Fair at the U.S. House of Representative in Longworth Building. The event was sponsored by AUVSI,  The team discussed FIRST with several Congressmen including Rep Byers (VA) and Rep Hultgren (IL) and demonstrated two of their FRC robots to gathered guests. Guests included congressional staff members and corporate exhibitors.</p>
 				<div class="img-row-2">
-			        <img src="/images/rep_1.jpg" alt="A team member with a congress representative.">
-			        <img src="/images/rep_2.JPG" alt="The team posing with a congress representative.">
+			        <img src="/images/outreach/AUVSI/rep_1.jpg" alt="A team member with a congress representative.">
+			        <img src="/images/outreach/AUVSI/rep_2.JPG" alt="The team posing with a congress representative.">
 				</div>
 				<div class="img-row-2">
-			        <img src="/images/rep_3.JPG" alt="The team huddling around the robot.">
-			        <img src="/images/rep_4.JPG" alt="A crowd including team members and others around a table.">
+			        <img src="/images/outreach/AUVSI/rep_3.JPG" alt="The team huddling around the robot.">
+			        <img src="/images/outreach/AUVSI/rep_4.JPG" alt="A crowd including team members and others around a table.">
 			    </div>
 	<h1>College Outreach</h1>
 		<h5>Virginia Tech Maker Faire</h5>


### PR DESCRIPTION
While testing the STEAM night images on localhost, I found that the image path for the pictures with representatives was incorrect in the HTML for the images due to new folders. This commit fixes that.