### PR TITLE
Automatically generate yearly award banners

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gem 'github-pages'
 gem 'tbarb'
 group :jekyll_plugins do
     gem 'octopress-autoprefixer'
-    gem 'banner-locator'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 ruby RUBY_VERSION
 
-gem 'github-pages', group: :jekyll_plugins
-gem 'octopress-autoprefixer'
+gem 'github-pages' 
+gem 'tbarb'
+group :jekyll_plugins do
+    gem 'octopress-autoprefixer'
+    gem 'banner-locator', :path => '/Users/lestera/Desktop/banner-locator'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'github-pages'
 gem 'tbarb'
 group :jekyll_plugins do
     gem 'octopress-autoprefixer'
-    gem 'banner-locator', :path => '/Users/lestera/Desktop/banner-locator'
+    gem 'banner-locator'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 source 'https://rubygems.org'
 ruby RUBY_VERSION
 
-gem 'github-pages' 
-gem 'tbarb'
-group :jekyll_plugins do
-    gem 'octopress-autoprefixer'
-end
+gem 'github-pages', group: :jekyll_plugins
+gem 'octopress-autoprefixer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,3 @@
-PATH
-  remote: /Users/lestera/Desktop/banner-locator
-  specs:
-    banner-locator (0.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -15,6 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (9.5.0)
       execjs
+    banner-locator (0.1.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -253,7 +249,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  banner-locator!
+  banner-locator
   github-pages
   octopress-autoprefixer
   tbarb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: /Users/lestera/Desktop/banner-locator
+  specs:
+    banner-locator (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -8,7 +13,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.1.4)
+    autoprefixer-rails (9.5.0)
       execjs
     coffee-script (2.4.1)
       coffee-script-source
@@ -17,19 +22,19 @@ GEM
     colorator (1.1.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     dnsruby (1.61.2)
       addressable (~> 2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.11.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.25)
+    ffi (1.10.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (192)
@@ -107,9 +112,9 @@ GEM
     jekyll-coffeescript (1.1.1)
       coffee-script (~> 2.2)
       coffee-script-source (~> 1.11.1)
-    jekyll-commonmark (1.2.0)
+    jekyll-commonmark (1.3.1)
       commonmarker (~> 0.14)
-      jekyll (>= 3.0, < 4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-commonmark-ghpages (0.1.5)
       commonmarker (~> 0.17.6)
       jekyll-commonmark (~> 1)
@@ -187,7 +192,7 @@ GEM
       jekyll-seo-tag (~> 2.0)
     jekyll-titles-from-headings (0.5.1)
       jekyll (~> 3.3)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
     jemoji (0.10.1)
       gemoji (~> 3.0)
@@ -209,24 +214,24 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    octokit (4.12.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     octopress-autoprefixer (2.0.1)
       autoprefixer-rails
       jekyll (~> 3.0)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rouge (2.2.1)
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    safe_yaml (1.0.5)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -234,10 +239,11 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    tbarb (0.3.1)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -247,11 +253,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  banner-locator!
   github-pages
   octopress-autoprefixer
+  tbarb
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (9.5.0)
       execjs
-    banner-locator (0.1.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -235,7 +234,6 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    tbarb (0.3.1)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
@@ -249,10 +247,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  banner-locator
   github-pages
   octopress-autoprefixer
-  tbarb
 
 RUBY VERSION
    ruby 2.3.3p222

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,4 @@ include:
     - _pages
 plugins:
     - octopress-autoprefixer
+    - banner-locator

--- a/_config.yml
+++ b/_config.yml
@@ -25,4 +25,3 @@ include:
     - _pages
 plugins:
     - octopress-autoprefixer
-    - banner-locator

--- a/_data/banners.yml
+++ b/_data/banners.yml
@@ -36,3 +36,25 @@
 - Washington Gracious Professionalism
 - Washington Finalist
 - Richmond Winner
+2009:
+- Washington Outstanding Volunteer
+2008:
+- Annapolis Regional Winner
+2007:
+- Annapolis Delphi "Driving Tomorrow's Technology" Award
+2006: []
+2005: []
+2004:
+- Richmond Rookie All Star Award
+2003: []
+2002: []
+2001: []
+2000: []
+1999: []
+1998: []
+1997: []
+1996: []
+1995: []
+1994: []
+1993: []
+1992: []

--- a/_data/banners.yml
+++ b/_data/banners.yml
@@ -1,38 +1,38 @@
 ---
 2019:
-- award: Oxon Hill District Event Winner
-- award: Oxon Hill Innovation in Control
-- award: Haymarket District Event Finalist
-- award: Haymarket Excellence in Engineering
+- Oxon Hill District Event Winner
+- Oxon Hill Innovation in Control
+- Haymarket District Event Finalist
+- Haymarket Excellence in Engineering
 2018:
-- award: College Park FIRST Dean's List Finalist Award
-- award: Detroit FIRST Dean's List Award
-- award: Alexandria Innovation in Control
-- award: Haymarket Judges' Award
+- College Park FIRST Dean's List Finalist Award
+- Detroit FIRST Dean's List Award
+- Alexandria Innovation in Control
+- Haymarket Judges' Award
 2017:
-- award: Richmond Innovation in Control
-- award: Owings Mills District Event Finalist
-- award: Owings Mills Creativity
-- award: Haymarket Innovation in Control
+- Richmond Innovation in Control
+- Owings Mills District Event Finalist
+- Owings Mills Creativity
+- Haymarket Innovation in Control
 2016:
-- award: College Park District Championship Winner
-- award: College Park Innovation in Control
-- award: Bethesda District Event Winner
-- award: Bethesda Industrial Design
-- award: Haymarket District Event Winner
-- award: Haymarket Innovation in Control
+- College Park District Championship Winner
+- College Park Innovation in Control
+- Bethesda District Event Winner
+- Bethesda Industrial Design
+- Haymarket District Event Winner
+- Haymarket Innovation in Control
 2015:
-- award: Fairfax Innovation in Control
+- Fairfax Innovation in Control
 2014:
-- award: Fairfax Regional Finalist
-- award: Fairfax Woodie Flowers Finalist Award
-- award: Richmond Industrial Design
-- award: Richmond Regional Finalist
+- Fairfax Regional Finalist
+- Fairfax Woodie Flowers Finalist Award
+- Richmond Industrial Design
+- Richmond Regional Finalist
 2013: []
 2012:
-- award: Washington Gracious Professionalism
+- Washington Gracious Professionalism
 2011: []
 2010:
-- award: Washington Gracious Professionalism
-- award: Washington Finalist
-- award: Richmond Winner
+- Washington Gracious Professionalism
+- Washington Finalist
+- Richmond Winner

--- a/_data/banners.yml
+++ b/_data/banners.yml
@@ -1,0 +1,38 @@
+---
+2019:
+- award: Oxon Hill District Event Winner
+- award: Oxon Hill Innovation in Control
+- award: Haymarket District Event Finalist
+- award: Haymarket Excellence in Engineering
+2018:
+- award: College Park FIRST Dean's List Finalist Award
+- award: Detroit FIRST Dean's List Award
+- award: Alexandria Innovation in Control
+- award: Haymarket Judges' Award
+2017:
+- award: Richmond Innovation in Control
+- award: Owings Mills District Event Finalist
+- award: Owings Mills Creativity
+- award: Haymarket Innovation in Control
+2016:
+- award: College Park District Championship Winner
+- award: College Park Innovation in Control
+- award: Bethesda District Event Winner
+- award: Bethesda Industrial Design
+- award: Haymarket District Event Winner
+- award: Haymarket Innovation in Control
+2015:
+- award: Fairfax Innovation in Control
+2014:
+- award: Fairfax Regional Finalist
+- award: Fairfax Woodie Flowers Finalist Award
+- award: Richmond Industrial Design
+- award: Richmond Regional Finalist
+2013: []
+2012:
+- award: Washington Gracious Professionalism
+2011: []
+2010:
+- award: Washington Gracious Professionalism
+- award: Washington Finalist
+- award: Richmond Winner

--- a/_includes/banners.html
+++ b/_includes/banners.html
@@ -1,0 +1,5 @@
+<ul class="banners">
+    {% for banner in site.data.banners[page.year] %}
+        <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
+    {% endfor %}
+</ul>

--- a/_includes/banners.html
+++ b/_includes/banners.html
@@ -1,5 +1,5 @@
 <ul class="banners">
-    {% for banner in site.data.banners[page.year] %}
-        <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
+    {% for banner in site.data.banners[include.year] %}
+        <li><img src="/images/first.svg">{{ include.year }}<br> {{ banner }}</li>
     {% endfor %}
 </ul>

--- a/_pages/robot/2014.html
+++ b/_pages/robot/2014.html
@@ -11,7 +11,7 @@ year: 2014
     <h1>2014 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <p>The FIRST challenge for this year was called Aerial Assist. The challenge included throwing and catching a large ball. You got points for throwing, catching, and scoring with the ball. For more information, see the <a href="https://www.youtube.com/watch?v=oxp4dkMQ1Vo">official game animation</a>.</p>

--- a/_pages/robot/2014.html
+++ b/_pages/robot/2014.html
@@ -10,7 +10,7 @@ year: 2014
 <main>
     <h1>2014 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/_pages/robot/2014.html
+++ b/_pages/robot/2014.html
@@ -5,11 +5,10 @@ permalink: /robot/2014
 stylesheets:
 - banners
 description: Our robot and the challenge for the 2014 season
-year: 2014
 ---
 <main>
     <h1>2014 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2014 %}
     <p>The FIRST challenge for this year was called Aerial Assist. The challenge included throwing and catching a large ball. You got points for throwing, catching, and scoring with the ball. For more information, see the <a href="https://www.youtube.com/watch?v=oxp4dkMQ1Vo">official game animation</a>.</p>
     <h5>Design</h5>
     <p>The main frame of the robot is made of 80/20 stock aluminum. We chose 80/20 because it is strong, yet light. The catapult is made of c-channel and sheet aluminum. Our intake system is composed of an arm, controlled by pistons, which has an axle and motor on it. The motor turns 6 inch wheels, which accumulate the ball. We decided to go with mecanum drive this year, because we believe it is vital to be able to get to a ball quickly, and pick it up. The mecanum allows us to strafe around defensive robots, allowing us to be a strong offensive team against a strong defensive team.</p>

--- a/_pages/robot/2014.html
+++ b/_pages/robot/2014.html
@@ -9,11 +9,7 @@ year: 2014
 ---
 <main>
     <h1>2014 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <p>The FIRST challenge for this year was called Aerial Assist. The challenge included throwing and catching a large ball. You got points for throwing, catching, and scoring with the ball. For more information, see the <a href="https://www.youtube.com/watch?v=oxp4dkMQ1Vo">official game animation</a>.</p>
     <h5>Design</h5>
     <p>The main frame of the robot is made of 80/20 stock aluminum. We chose 80/20 because it is strong, yet light. The catapult is made of c-channel and sheet aluminum. Our intake system is composed of an arm, controlled by pistons, which has an axle and motor on it. The motor turns 6 inch wheels, which accumulate the ball. We decided to go with mecanum drive this year, because we believe it is vital to be able to get to a ball quickly, and pick it up. The mecanum allows us to strafe around defensive robots, allowing us to be a strong offensive team against a strong defensive team.</p>

--- a/_pages/robot/2014.html
+++ b/_pages/robot/2014.html
@@ -5,12 +5,14 @@ permalink: /robot/2014
 stylesheets:
 - banners
 description: Our robot and the challenge for the 2014 season
+year: 2014
 ---
 <main>
     <h1>2014 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2014 Woodie Flowers Finalist</li>
-        <li><img src="/images/first.svg">2014 Industrial Design (Virginia)</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <p>The FIRST challenge for this year was called Aerial Assist. The challenge included throwing and catching a large ball. You got points for throwing, catching, and scoring with the ball. For more information, see the <a href="https://www.youtube.com/watch?v=oxp4dkMQ1Vo">official game animation</a>.</p>
     <h5>Design</h5>

--- a/_pages/robot/2015.html
+++ b/_pages/robot/2015.html
@@ -11,11 +11,7 @@ year: 2015
 ---
 <main>
     <h1>2015 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <p>The FIRST challenge for this year was called Recycle Rush. The challenge included stacking totes and cans as high as possible and capping the stacks with cans and noodles. For a more detailed description, see <a href="https://www.youtube.com/watch?v=mAN1B7oKDXE">the game reveal video</a>.</p>
     <h5>Autonomous</h5>
     <ul>

--- a/_pages/robot/2015.html
+++ b/_pages/robot/2015.html
@@ -12,7 +12,7 @@ year: 2015
 <main>
     <h1>2015 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/_pages/robot/2015.html
+++ b/_pages/robot/2015.html
@@ -7,11 +7,10 @@ stylesheets:
 - recycle
 - fixedbackground
 description: Our robot and the challenge for the 2015 season
-year: 2015
 ---
 <main>
     <h1>2015 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2015 %}
     <p>The FIRST challenge for this year was called Recycle Rush. The challenge included stacking totes and cans as high as possible and capping the stacks with cans and noodles. For a more detailed description, see <a href="https://www.youtube.com/watch?v=mAN1B7oKDXE">the game reveal video</a>.</p>
     <h5>Autonomous</h5>
     <ul>

--- a/_pages/robot/2015.html
+++ b/_pages/robot/2015.html
@@ -7,11 +7,14 @@ stylesheets:
 - recycle
 - fixedbackground
 description: Our robot and the challenge for the 2015 season
+year: 2015
 ---
 <main>
     <h1>2015 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2015 Innovation in Control (DC)</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <p>The FIRST challenge for this year was called Recycle Rush. The challenge included stacking totes and cans as high as possible and capping the stacks with cans and noodles. For a more detailed description, see <a href="https://www.youtube.com/watch?v=mAN1B7oKDXE">the game reveal video</a>.</p>
     <h5>Autonomous</h5>

--- a/_pages/robot/2015.html
+++ b/_pages/robot/2015.html
@@ -13,7 +13,7 @@ year: 2015
     <h1>2015 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <p>The FIRST challenge for this year was called Recycle Rush. The challenge included stacking totes and cans as high as possible and capping the stacks with cans and noodles. For a more detailed description, see <a href="https://www.youtube.com/watch?v=mAN1B7oKDXE">the game reveal video</a>.</p>

--- a/_pages/robot/2016.html
+++ b/_pages/robot/2016.html
@@ -7,11 +7,10 @@ stylesheets:
 - medieval
 - fixedbackground
 description: Our robot and the challenge for the 2016 season
-year: 2016
 ---
 <main>
     <h1>2016 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2016 %}
     <img src="/images/robots/2016/robot.jpg" alt="The 2016 robot.">
     <p>The 2016 FIRST challenge was called FIRST Stronghold. The challenge involved crossing a variable series of defenses, scoring balls into low and high goals, and lifting the robot several feet into the air. For a more detailed description, see <a href="https://www.youtube.com/watch?v=VqOKzoHJDjA">the official video reveal</a>.</p>
     <p>Team 1418 was recognized as part of the top 1% of teams out of the 3,128 active at the time, as well as the best team in Virginia, Maryland, Delaware, West Virginia, and Washington, DC.</p>

--- a/_pages/robot/2016.html
+++ b/_pages/robot/2016.html
@@ -11,11 +11,7 @@ year: 2016
 ---
 <main>
     <h1>2016 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <img src="/images/robots/2016/robot.jpg" alt="The 2016 robot.">
     <p>The 2016 FIRST challenge was called FIRST Stronghold. The challenge involved crossing a variable series of defenses, scoring balls into low and high goals, and lifting the robot several feet into the air. For a more detailed description, see <a href="https://www.youtube.com/watch?v=VqOKzoHJDjA">the official video reveal</a>.</p>
     <p>Team 1418 was recognized as part of the top 1% of teams out of the 3,128 active at the time, as well as the best team in Virginia, Maryland, Delaware, West Virginia, and Washington, DC.</p>

--- a/_pages/robot/2016.html
+++ b/_pages/robot/2016.html
@@ -12,7 +12,7 @@ year: 2016
 <main>
     <h1>2016 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/_pages/robot/2016.html
+++ b/_pages/robot/2016.html
@@ -7,16 +7,14 @@ stylesheets:
 - medieval
 - fixedbackground
 description: Our robot and the challenge for the 2016 season
+year: 2016
 ---
 <main>
     <h1>2016 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2016 Chesapeake District Champions</li>
-        <li><img src="/images/first.svg">2016 Chesapeake Innovation in Control</li>
-        <li><img src="/images/first.svg">2016 Greater DC Event Winners</li>
-        <li><img src="/images/first.svg">2016 Greater DC Industrial Design</li>
-        <li><img src="/images/first.svg">2016 Northern VA Event Winners</li>
-        <li><img src="/images/first.svg">2016 North Virginia Innovation in Control</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <img src="/images/robots/2016/robot.jpg" alt="The 2016 robot.">
     <p>The 2016 FIRST challenge was called FIRST Stronghold. The challenge involved crossing a variable series of defenses, scoring balls into low and high goals, and lifting the robot several feet into the air. For a more detailed description, see <a href="https://www.youtube.com/watch?v=VqOKzoHJDjA">the official video reveal</a>.</p>

--- a/_pages/robot/2016.html
+++ b/_pages/robot/2016.html
@@ -13,7 +13,7 @@ year: 2016
     <h1>2016 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <img src="/images/robots/2016/robot.jpg" alt="The 2016 robot.">

--- a/_pages/robot/2017.html
+++ b/_pages/robot/2017.html
@@ -10,11 +10,7 @@ year: 2017
 ---
 <main>
     <h1>2017 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <img src="/images/robots/2017.jpg" alt="The 2017 robot being carried onto the ground.">
     <p>The 2017 game is proving to be one of the most challenging to date for our experienced team. Designed by Disney, FIRST STEAMWORKS aims to challenge teams to create mechanisms capable of delivering 11 inch diameter gears to human players stationed on the Jules Verne inspired airship. Teams also have the task of shooting 5 inch diameter wiffle balls to add fuel to the boiler, sending steam to fuel the airship. For a more detailed description of the game, see the <a href="https://www.youtube.com/watch?v=EMiNmJW7enI">the official video reveal</a>.</p>
     <h5>Robot Abilities</h5>

--- a/_pages/robot/2017.html
+++ b/_pages/robot/2017.html
@@ -6,13 +6,14 @@ stylesheets:
 - banners
 - steampunk
 description: Our robot and the challenge for the 2017 season
+year: 2017
 ---
 <main>
     <h1>2017 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2017<br> North VA Innovation in Control</li>
-        <li><img src="/images/first.svg">2017<br> North MD Creativity Award</li>
-        <li><img src="/images/first.svg">2017<br> Chesapeake Innovation in Control</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <img src="/images/robots/2017.jpg" alt="The 2017 robot being carried onto the ground.">
     <p>The 2017 game is proving to be one of the most challenging to date for our experienced team. Designed by Disney, FIRST STEAMWORKS aims to challenge teams to create mechanisms capable of delivering 11 inch diameter gears to human players stationed on the Jules Verne inspired airship. Teams also have the task of shooting 5 inch diameter wiffle balls to add fuel to the boiler, sending steam to fuel the airship. For a more detailed description of the game, see the <a href="https://www.youtube.com/watch?v=EMiNmJW7enI">the official video reveal</a>.</p>

--- a/_pages/robot/2017.html
+++ b/_pages/robot/2017.html
@@ -11,7 +11,7 @@ year: 2017
 <main>
     <h1>2017 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/_pages/robot/2017.html
+++ b/_pages/robot/2017.html
@@ -12,7 +12,7 @@ year: 2017
     <h1>2017 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <img src="/images/robots/2017.jpg" alt="The 2017 robot being carried onto the ground.">

--- a/_pages/robot/2017.html
+++ b/_pages/robot/2017.html
@@ -6,11 +6,10 @@ stylesheets:
 - banners
 - steampunk
 description: Our robot and the challenge for the 2017 season
-year: 2017
 ---
 <main>
     <h1>2017 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2017 %}
     <img src="/images/robots/2017.jpg" alt="The 2017 robot being carried onto the ground.">
     <p>The 2017 game is proving to be one of the most challenging to date for our experienced team. Designed by Disney, FIRST STEAMWORKS aims to challenge teams to create mechanisms capable of delivering 11 inch diameter gears to human players stationed on the Jules Verne inspired airship. Teams also have the task of shooting 5 inch diameter wiffle balls to add fuel to the boiler, sending steam to fuel the airship. For a more detailed description of the game, see the <a href="https://www.youtube.com/watch?v=EMiNmJW7enI">the official video reveal</a>.</p>
     <h5>Robot Abilities</h5>

--- a/_pages/robot/2018.html
+++ b/_pages/robot/2018.html
@@ -7,14 +7,14 @@ stylesheets:
 - powerup
 - fixedbackground
 description: Our robot and the challenge for the 2018 season
+year: 2018
 ---
 <main>
     <h1>2018 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2018<br> Northern Virginia Judges' Award</li>
-        <li><img src="/images/first.svg">2018<br> Greater DC Innovation in Control</li>
-        <li><img src="/images/first.svg">2018<br> FIRST Dean's List Finalist Award</li>
-        <li><img src="/images/first.svg">2018<br> FIRST Dean's List Award</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <img src="/images/robots/2018/ROBTWO.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2018/ROBFOUR.JPG" alt="This shows us working on an earlier version of our robot.">

--- a/_pages/robot/2018.html
+++ b/_pages/robot/2018.html
@@ -7,11 +7,10 @@ stylesheets:
 - powerup
 - fixedbackground
 description: Our robot and the challenge for the 2018 season
-year: 2018
 ---
 <main>
     <h1>2018 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2018 %}
     <img src="/images/robots/2018/ROBTWO.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2018/ROBFOUR.JPG" alt="This shows us working on an earlier version of our robot.">
     <p>The 2018 game's fusion of 20th century arcade gaming and 21st century robotics is possibly one of the most challenging scenarios to date, involving placing cubes in various areas to earn points. For a more detailed description of the game, see <a href="https://youtu.be/HZbdwYiCY74">the official video reveal</a>.</p>

--- a/_pages/robot/2018.html
+++ b/_pages/robot/2018.html
@@ -11,11 +11,7 @@ year: 2018
 ---
 <main>
     <h1>2018 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <img src="/images/robots/2018/ROBTWO.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2018/ROBFOUR.JPG" alt="This shows us working on an earlier version of our robot.">
     <p>The 2018 game's fusion of 20th century arcade gaming and 21st century robotics is possibly one of the most challenging scenarios to date, involving placing cubes in various areas to earn points. For a more detailed description of the game, see <a href="https://youtu.be/HZbdwYiCY74">the official video reveal</a>.</p>

--- a/_pages/robot/2018.html
+++ b/_pages/robot/2018.html
@@ -12,7 +12,7 @@ year: 2018
 <main>
     <h1>2018 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/_pages/robot/2018.html
+++ b/_pages/robot/2018.html
@@ -13,7 +13,7 @@ year: 2018
     <h1>2018 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <img src="/images/robots/2018/ROBTWO.JPG" alt="Our current robot (side view).">

--- a/_pages/robot/2019.html
+++ b/_pages/robot/2019.html
@@ -16,7 +16,7 @@ year: 2019
     <h1>2019 Robot</h1>
     <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
     </ul>
     <img src="/images/robots/2019/2019-profile.JPG" alt="Our current robot (side view).">

--- a/_pages/robot/2019.html
+++ b/_pages/robot/2019.html
@@ -10,13 +10,14 @@ stylesheets:
 scripts:
 - measurements
 description: Our robot and the challenge for the 2019 season
+year: 2019
 ---
 <main>
     <h1>2019 Robot</h1>
     <ul class="banners">
-        <li><img src="/images/first.svg">2019<br> Oxon Hill Event Winners</li>
-        <li><img src="/images/first.svg">2019<br> Oxon Hill Innovation in Control</li>
-        <li><img src="/images/first.svg">2019<br> Haymarket Virginia Excellence in Engineering</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
     </ul>
     <img src="/images/robots/2019/2019-profile.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2019/2019-work.JPG" alt="This shows us working on our robot.">

--- a/_pages/robot/2019.html
+++ b/_pages/robot/2019.html
@@ -10,11 +10,10 @@ stylesheets:
 scripts:
 - measurements
 description: Our robot and the challenge for the 2019 season
-year: 2019
 ---
 <main>
     <h1>2019 Robot</h1>
-    {% include banners.html %}
+    {% include banners.html year=2019 %}
     <img src="/images/robots/2019/2019-profile.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2019/2019-work.JPG" alt="This shows us working on our robot.">
     <ul id="measurements">

--- a/_pages/robot/2019.html
+++ b/_pages/robot/2019.html
@@ -14,11 +14,7 @@ year: 2019
 ---
 <main>
     <h1>2019 Robot</h1>
-    <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-    </ul>
+    {% include banners.html %}
     <img src="/images/robots/2019/2019-profile.JPG" alt="Our current robot (side view).">
     <img src="/images/robots/2019/2019-work.JPG" alt="This shows us working on our robot.">
     <ul id="measurements">

--- a/_pages/robot/2019.html
+++ b/_pages/robot/2019.html
@@ -15,7 +15,7 @@ year: 2019
 <main>
     <h1>2019 Robot</h1>
     <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
     </ul>

--- a/banner-locator.rb
+++ b/banner-locator.rb
@@ -3,26 +3,26 @@ require 'yaml'
 
 tba = TBA.new('AykWePEZPKTjZxW6y7MbiTEpTfUlWrszcX5QBpIDUEZPBCJydltvhfd88MsBXxdS')
 year = DateTime.now.year
-awardMap = {}
+award_map = {}
 10.times do |count|
   awards = tba.team_awards(1418, year)
-  awardList = []
+  award_list = []
   awards.each do |award|
-    awardName = award['name'].split(' Award ')[0]
+    award_name = award['name'].split(' Award ')[0]
     events = tba.team_events(1418, year, true)
-    eventName = ''
+    event_name = ''
     events.each do |event|
       if event['key'] == award['event_key']
-        eventName = event['city']
+        event_name = event['city']
       end
     end
-    if eventName == ''
+    if event_name == ''
       next
     end
-    awardName = eventName + ' ' + awardName
-    awardList.push(awardName)
+    award_name = event_name + ' ' + award_name
+    award_list.push(award_name)
   end
-  awardMap[year] = awardList
+  award_map[year] = award_list
   year -= 1
 end
-File.open("_data/banners.yml", "w") { |file| file.write(awardMap.to_yaml)}
+File.open("_data/banners.yml", "w") { |file| file.write(award_map.to_yaml)}

--- a/banner-locator.rb
+++ b/banner-locator.rb
@@ -20,7 +20,7 @@ awardMap = {}
       next
     end
     awardName = eventName + ' ' + awardName
-    awardList.push({'award'=> awardName})
+    awardList.push(awardName)
   end
   awardMap[year] = awardList
   year -= 1

--- a/banner-locator.rb
+++ b/banner-locator.rb
@@ -1,23 +1,24 @@
 require 'tbarb'
 require 'yaml'
 
+TEAM = 1418
 tba = TBA.new('AykWePEZPKTjZxW6y7MbiTEpTfUlWrszcX5QBpIDUEZPBCJydltvhfd88MsBXxdS')
 year = DateTime.now.year
 award_map = {}
-10.times do |count|
-  awards = tba.team_awards(1418, year)
+(year - 1991).times do |count|
+  awards = tba.team_awards(TEAM, year)
   award_list = []
   awards.each do |award|
     award_name = award['name'].split(' Award ')[0]
-    events = tba.team_events(1418, year, true)
+    events = tba.team_events(TEAM, year, true)
     event_name = ''
     events.each do |event|
       if event['key'] == award['event_key']
         event_name = event['city']
       end
     end
-    if event_name == ''
-      next
+    if event_name == nil
+      event_name = ''
     end
     award_name = event_name + ' ' + award_name
     award_list.push(award_name)

--- a/banner-locator.rb
+++ b/banner-locator.rb
@@ -1,0 +1,28 @@
+require 'tbarb'
+require 'yaml'
+
+tba = TBA.new('AykWePEZPKTjZxW6y7MbiTEpTfUlWrszcX5QBpIDUEZPBCJydltvhfd88MsBXxdS')
+year = DateTime.now.year
+awardMap = {}
+10.times do |count|
+  awards = tba.team_awards(1418, year)
+  awardList = []
+  awards.each do |award|
+    awardName = award['name'].split(' Award ')[0]
+    events = tba.team_events(1418, year, true)
+    eventName = ''
+    events.each do |event|
+      if event['key'] == award['event_key']
+        eventName = event['city']
+      end
+    end
+    if eventName == ''
+      next
+    end
+    awardName = eventName + ' ' + awardName
+    awardList.push({'award'=> awardName})
+  end
+  awardMap[year] = awardList
+  year -= 1
+end
+File.open("_data/banners.yml", "w") { |file| file.write(awardMap.to_yaml)}

--- a/css/banners.sass
+++ b/css/banners.sass
@@ -4,7 +4,7 @@
     display: block
     margin: 0 auto
     width: 100vw
-    height: 200px
+    height: 199px
     text-align: center
     padding: 0 20px
     line-height: 1.2

--- a/css/banners.sass
+++ b/css/banners.sass
@@ -4,6 +4,7 @@
     display: block
     margin: 0 auto
     width: 100vw
+    // Hides a 1px overflow on any banner dropped onto a new line (screen size)
     height: 199px
     text-align: center
     padding: 0 20px

--- a/css/index.sass
+++ b/css/index.sass
@@ -86,6 +86,7 @@ main
     float: right
     width: 50%
     margin: 10px 20px 10px 0px
+    overflow: hidden
 
 @media (min-width: 850px) and (max-width: 1070px)
     .banners

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@ stylesheets:
 scripts:
 - index
 description: We are team 1418 Vae Victis, a FIRST Robotics Competition (FRC) Team from George Mason High School in Falls Church, VA. We strive for student enrichment, technical advancement, and success in the FIRST Robotics Competition.
+year: 2019
 ---
 
 <div class="bg"></div>
@@ -30,9 +31,9 @@ description: We are team 1418 Vae Victis, a FIRST Robotics Competition (FRC) Tea
     <div>
         <img src="/images/worlds2018.jpg" alt="The team at the 2018 FIRST World Championships, in front of the FIRST Logo at the Cobo Center in Detroit.">
         <ul class="banners">
-            <li><img src="/images/first.svg">2019<br> Oxon Hill Event Winners</li>
-            <li><img src="/images/first.svg">2019<br> Oxon Hill Innovation in Control</li>
-            <li><img src="/images/first.svg">2019<br> Haymarket Virginia Excellence in Engineering</li>
+        {% for banner in page.banners %}
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+        {% endfor %}
         </ul>
         <p>We are team 1418 Vae Victis, a <a href="http://firstinspires.org/robotics/frc">FIRST Robotics Competition (FRC)</a> team from George Mason High School in Falls Church, VA. Since our founding in 2004, our team has grown in every way, and has maintained a high place in competition and in the community. To do this, we maintain an active and engaged student body of around fifteen students who work with the team on and off season. We are proud to have experienced success in competition. We have made it to the FIRST World Championship in St. Louis, Missouri (2016 and 2017) and Detroit, Michigan (2018) for the past three years, and plan to continue our streak. Outside of competition, we pride ourselves on involvement in our community. We have hosted free summer camps to educate elementary school students on basic LEGO Robotics, and volunteer to help run FIRST Lego League competitions every year. We've even helped to start robotics teams in rural Ecuador and help educate students living there. More information about our outreach efforts can be found <a href="outreach">here</a>.</p>
         <br>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ year: 2019
     <div>
         <img src="/images/worlds2018.jpg" alt="The team at the 2018 FIRST World Championships, in front of the FIRST Logo at the Cobo Center in Detroit.">
         <ul class="banners">
-        {% for banner in page.banners %}
+        {% for banner in site.data.banners[page.year] %}
             <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
         {% endfor %}
         </ul>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@ stylesheets:
 scripts:
 - index
 description: We are team 1418 Vae Victis, a FIRST Robotics Competition (FRC) Team from George Mason High School in Falls Church, VA. We strive for student enrichment, technical advancement, and success in the FIRST Robotics Competition.
-year: 2019
 ---
 
 <div class="bg"></div>
@@ -30,7 +29,7 @@ year: 2019
 <main>
     <div>
         <img src="/images/worlds2018.jpg" alt="The team at the 2018 FIRST World Championships, in front of the FIRST Logo at the Cobo Center in Detroit.">
-        {% include banners.html %}
+        {% include banners.html year=2019 %}
         <p>We are team 1418 Vae Victis, a <a href="http://firstinspires.org/robotics/frc">FIRST Robotics Competition (FRC)</a> team from George Mason High School in Falls Church, VA. Since our founding in 2004, our team has grown in every way, and has maintained a high place in competition and in the community. To do this, we maintain an active and engaged student body of around fifteen students who work with the team on and off season. We are proud to have experienced success in competition. We have made it to the FIRST World Championship in St. Louis, Missouri (2016 and 2017) and Detroit, Michigan (2018) for the past three years, and plan to continue our streak. Outside of competition, we pride ourselves on involvement in our community. We have hosted free summer camps to educate elementary school students on basic LEGO Robotics, and volunteer to help run FIRST Lego League competitions every year. We've even helped to start robotics teams in rural Ecuador and help educate students living there. More information about our outreach efforts can be found <a href="outreach">here</a>.</p>
         <br>
         <p>If you'd like to help us with fundraising, please visit <a href="sponsorship">this page</a>.</p>

--- a/index.html
+++ b/index.html
@@ -30,11 +30,7 @@ year: 2019
 <main>
     <div>
         <img src="/images/worlds2018.jpg" alt="The team at the 2018 FIRST World Championships, in front of the FIRST Logo at the Cobo Center in Detroit.">
-        <ul class="banners">
-        {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
-        {% endfor %}
-        </ul>
+        {% include banners.html %}
         <p>We are team 1418 Vae Victis, a <a href="http://firstinspires.org/robotics/frc">FIRST Robotics Competition (FRC)</a> team from George Mason High School in Falls Church, VA. Since our founding in 2004, our team has grown in every way, and has maintained a high place in competition and in the community. To do this, we maintain an active and engaged student body of around fifteen students who work with the team on and off season. We are proud to have experienced success in competition. We have made it to the FIRST World Championship in St. Louis, Missouri (2016 and 2017) and Detroit, Michigan (2018) for the past three years, and plan to continue our streak. Outside of competition, we pride ourselves on involvement in our community. We have hosted free summer camps to educate elementary school students on basic LEGO Robotics, and volunteer to help run FIRST Lego League competitions every year. We've even helped to start robotics teams in rural Ecuador and help educate students living there. More information about our outreach efforts can be found <a href="outreach">here</a>.</p>
         <br>
         <p>If you'd like to help us with fundraising, please visit <a href="sponsorship">this page</a>.</p>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ year: 2019
         <img src="/images/worlds2018.jpg" alt="The team at the 2018 FIRST World Championships, in front of the FIRST Logo at the Cobo Center in Detroit.">
         <ul class="banners">
         {% for banner in site.data.banners[page.year] %}
-            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner.award }}</li>
+            <li><img src="/images/first.svg">{{ page.year }}<br> {{ banner }}</li>
         {% endfor %}
         </ul>
         <p>We are team 1418 Vae Victis, a <a href="http://firstinspires.org/robotics/frc">FIRST Robotics Competition (FRC)</a> team from George Mason High School in Falls Church, VA. Since our founding in 2004, our team has grown in every way, and has maintained a high place in competition and in the community. To do this, we maintain an active and engaged student body of around fifteen students who work with the team on and off season. We are proud to have experienced success in competition. We have made it to the FIRST World Championship in St. Louis, Missouri (2016 and 2017) and Detroit, Michigan (2018) for the past three years, and plan to continue our streak. Outside of competition, we pride ourselves on involvement in our community. We have hosted free summer camps to educate elementary school students on basic LEGO Robotics, and volunteer to help run FIRST Lego League competitions every year. We've even helped to start robotics teams in rural Ecuador and help educate students living there. More information about our outreach efforts can be found <a href="outreach">here</a>.</p>


### PR DESCRIPTION
Closes #365 
~~I'll upload the code for the gem soon enough and transfer it to the 1418 organization. The gem uses the [Jekyll Generation Plugin](https://jekyllrb.com/docs/plugins/generators/) feature.~~

Unfortunately, Github Pages blocks the usage of Jekyll plugins. This restriction means I had to simply make a script which creates a yml file to be read by jekyll.

The data looks like this:

```
---
2019:
- award: Oxon Hill District Event Winner
- award: Oxon Hill Innovation in Control
- award: Haymarket District Event Finalist
- award: Haymarket Excellence in Engineering
2018:
- award: College Park FIRST Dean's List Finalist Award
- award: Detroit FIRST Dean's List Award
- award: Alexandria Innovation in Control
- award: Haymarket Judges' Award
```