### PR TITLE
Hide social icons when on a small screen

### DIFF
--- a/css/main.sass
+++ b/css/main.sass
@@ -512,3 +512,7 @@ footer ul
         width: 100%
     nav
         height: 100%
+
+@media (max-width: 450px)
+    header.shrink > .social
+        display: none


### PR DESCRIPTION
This fixes a bug where the social icons are displayed below the header on small screens.