### PR TITLE
remove import for stylesheet that doesn't exist

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,6 @@
     <meta property="og:image" content="http://1418.team/images/worlds2018.jpg">
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
     <link rel="icon" type="image/png" href="/images/favicon.png">
-    <link rel="stylesheet" href="/css/normalize.css">
     <link rel="stylesheet" href="/css/main.css">
     {% if page.stylesheets %}
         {% for stylesheet in page.stylesheets %}


### PR DESCRIPTION
I don't know why this is here so I'm removing it unless there's a reason to keep it